### PR TITLE
Fix type mismatch for struct.unpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Python library for interfacing with Espec North America chambers with P300, SCP-220, Watlow F4T &amp; Watlow F4S/D controllers.
 
 ## Requirements
-python 2.7.x
+python 3.x
 
 ## Installation
 ```pip install chamberconnectlibrary```
@@ -15,7 +15,7 @@ To ensure that the current version is used uninstall and then reinstall the libr
 
 ## Testing
 
-To test run chamberconnectlibrary-test.py(on windows using COM port #3, test script is located in Python2.7\Scripts directory)
+To test run chamberconnectlibrary-test.py(on windows using COM port #3, test script is located in Python3.x\Scripts directory)
 
 P300: ```chamberconnectlibrary-test.py Espec Serial \\.\COM3 19200```
 

--- a/chamberconnectlibrary/modbus.py
+++ b/chamberconnectlibrary/modbus.py
@@ -189,20 +189,20 @@ class Modbus(object):
 
     def decode_packet(self, packet, spacket):
         '''Decode the modbus request packet.'''
-        fcode = struct.unpack(">B", packet[1])[0]
-        addr = struct.unpack(">B", packet[0])[0]
+        fcode = struct.unpack(">B", bytes([packet[1]]))[0]
+        addr = struct.unpack(">B", bytes([packet[0]]))[0]
         if self.address != addr:
             shex = ":".join("{:02x}".format(ord(c) for c in spacket))
             rhex = ":".join("{:02x}".format(ord(c) for c in packet))
             raise ModbusError("Address error; Sent=%s, Recieved=%s" % (shex, rhex))
         if fcode > 127:
-            ecode = struct.unpack(">B", packet[2])[0]
+            ecode = struct.unpack(">B", bytes([packet[2]]))[0]
             ttp = (ecode, self.errorMessages.get(ecode, 'Unknown error code'))
             raise ModbusError('Modbus Error: Exception code = %d(%s)' % ttp)
 
         if fcode == 3: #Read holding register(s)
-            cnt = struct.unpack(">B", packet[2])[0]/2
-            return struct.unpack(">%dH" % cnt, packet[3:])
+            cnt = struct.unpack(">B", bytes([packet[2]]))[0] / 2
+            return struct.unpack(">%dH" % cnt, bytes(packet[3:]))
         elif fcode == 6:
             pass #nothing is required
         elif fcode == 16:


### PR DESCRIPTION
An error was occuring because `struct.unpack` was being called with
an `int` argument but it expects a `bytes` object. This was fixed
by converting the `int` arguments to `bytes` objects.

This was probably overlooked in the transition to python3.

Tested on a Watlow F4T device connecting through TCP:
```
python chamberconnectlibrary-test.py WatlowF4T TCP 192.168.0.222
```

Before this fix this test script would produce the following output:
```
Traceback (most recent call last):
  File "chamberconnectlibrary-test.py", line 37, in <module>
    baudrate=int(sys.argv[4]) if len(sys.argv) == 5 else 9600
  File "chamberconnectlibrary-test.py", line 27, in main
    ctlr.process_controller()
  File "C:\Program Files\Python36\lib\site-packages\chamberconnectlibrary-2.0.2-py3.6.egg\chamberconnectlibrary\controllerinterface.py", line 28, in wrapper
    return func(self, *args, **kwargs)
  File "C:\Program Files\Python36\lib\site-packages\chamberconnectlibrary-2.0.2-py3.6.egg\chamberconnectlibrary\watlowf4t.py", line 876, in process_controller
    prtnum = self.client.read_holding_string(16, 15)
  File "C:\Program Files\Python36\lib\site-packages\chamberconnectlibrary-2.0.2-py3.6.egg\chamberconnectlibrary\modbus.py", line 102, in read_holding_string
    val = self.read_holding(register, count)
  File "C:\Program Files\Python36\lib\site-packages\chamberconnectlibrary-2.0.2-py3.6.egg\chamberconnectlibrary\modbus.py", line 60, in read_holding
    return self.decode_packet(rval, packet)
  File "C:\Program Files\Python36\lib\site-packages\chamberconnectlibrary-2.0.2-py3.6.egg\chamberconnectlibrary\modbus.py", line 192, in decode_packet
    fcode = struct.unpack(">B", packet[1])[0]
TypeError: a bytes-like object is required, not 'int'

The test could not be run try:

chamberconnectlibrary_test controller interface ipORserialport [baudrate]
        controller: "Espec"/"EspecP300", "EspecSCP220", "WatlowF4", or "WatlowF4T"(default)
        interface: "Serial": Serial connection when "controller" is "Espec".
                   "RTU":Serial connection when "controller" is "WatlowF4T"
                   "TCP":TCP connection
        "hostORserialport": hostname for TCP, or serial port for RTU/Serial
        "baudrate": The baudrate for RTU/Serial, optional(default=9600)
```